### PR TITLE
Fixes for a few issues when using this extension with vscode-autohotkey2-lsp

### DIFF
--- a/ahkdbg/AHKBKManger.ahk
+++ b/ahkdbg/AHKBKManger.ahk
@@ -4,7 +4,7 @@ class BreakPointManger {
 		;         └- line
 		;          └- id, cond(bkinfo) 
         this.bkDict := {}
-        this.invaildBreakPointIdCount := 0
+        this.invalidBreakPointIdCount := 0
         this.Dbg_Session := ""
     }
 
@@ -19,9 +19,9 @@ class BreakPointManger {
         return this.bkDict[uri, line+0]
     }
 
-    addInvaild(uri, line) {
-        this.invaildBreakPointIdCount += 1
-        id := -this.invaildBreakPointIdCount
+    addInvalid(uri, line) {
+        this.invalidBreakPointIdCount += 1
+        id := -this.invalidBreakPointIdCount
         bkinfo := { "id": id, "cond": cond}
         this.bkDict[uri, line+0] := { "id": id, "cond": cond}
         return bkinfo

--- a/ahkdbg/AHKDebug.ahk
+++ b/ahkdbg/AHKDebug.ahk
@@ -54,7 +54,7 @@ class DebugSession extends Application
             case "path":
                 this._runtime.Init(env.arguments)
             Default:
-                response["body"] := {"error": CreateMessage(-1,env.arguments.program " launch fail`nInvaild path format`nOnly support path but pass format: " env.arguments.pathFormat)}
+                response["body"] := {"error": CreateMessage(-1,env.arguments.program " launch fail`nInvalid path format`nOnly support path but pass format: " env.arguments.pathFormat)}
                 return this.errorResponse(response, env)
         }
         return [response, InitializedEvent]
@@ -87,16 +87,16 @@ class DebugSession extends Application
         {
             if (env.arguments.AhkExecutable == "-1") 
             {
-                response["body"] := {"error": CreateMessage(-1, "Invaild runtime is passed by language server. Please check interpreter settings")}
+                response["body"] := {"error": CreateMessage(-1, "Invalid runtime is passed by language server. Please check interpreter settings")}
                 return this.errorResponse(response, env)
             }
             this._runtime.dbgCaptureStreams := (env.arguments.captureStreams == JSON.true) ? true : false
             this._runtime.AhkExecutable := FileExist(env.arguments.AhkExecutable) ? env.arguments.AhkExecutable : this._runtime.AhkExecutable
-            if (IsVaildPort(env.arguments.port))
+            if (IsValidPort(env.arguments.port))
                 this._runtime.dbgPort := env.arguments.port
             else
             {
-                response["body"] := {"error": CreateMessage(-1, "Invaild port passed. Expect an integer but got '" env.arguments.port "'. Please check interpreter settings")}
+                response["body"] := {"error": CreateMessage(-1, "Invalid port passed. Expect an integer but got '" env.arguments.port "'. Please check interpreter settings")}
                 return this.errorResponse(response, env)
             }
             noDebug := (env.arguments.noDebug == JSON.true) ? true : false
@@ -429,7 +429,7 @@ class DebugSession extends Application
     }
 }
 
-IsVaildPort(port) {
+IsValidPort(port) {
     if port is not Integer 
         return false
     ; convert port to integer

--- a/ahkdbg/AHKRuntime.ahk
+++ b/ahkdbg/AHKRuntime.ahk
@@ -99,7 +99,7 @@ class AHKRunTime
 			; Resolve that debugger does not exit, when syntax error at start.
 			; Why disconnection event is not sended under this situation?
 			if (Util_ProcessExist(Dbg_PID))
-				throw Exception("invaild language.", -1, this.Dbg_Lang)
+				throw Exception("invalid language.", -1, this.Dbg_Lang)
 			else
 				this.SendEvent(CreateTerminatedEvent())
 		}
@@ -381,7 +381,7 @@ class AHKRunTime
 			; return reason to frontend
 			dom := loadXML(Dbg_Response)
 			errorCode := dom.selectSingleNode("/response/error/@code").text
-			bkinfo := this.BkManger.addInvaild(DBGp_EncodeFileURI(path), bkinfo.line)
+			bkinfo := this.BkManger.addInvalid(DBGp_EncodeFileURI(path), bkinfo.line)
 			return {"verified": JSON.false, "line": line, "id": bkinfo.id, "source": sourcePath, "message": this.errorCodeToInfo[errorCode]}
 		}
 

--- a/ahkdbg/lib/stdio.ahk
+++ b/ahkdbg/lib/stdio.ahk
@@ -51,7 +51,7 @@ class StdIO
 	}
 	
 
-	SetProcesser(callback) 
+	SetProcessor(callback) 
 	{
 		this.processer := callback
 	}

--- a/ahkdbg/protocolserver.ahk
+++ b/ahkdbg/protocolserver.ahk
@@ -58,12 +58,12 @@ class ProtocolServer
 
 	HandleOneRequest(request_data)
     {
-		Logger("Hanlder:" request_data)
+		Logger("Handler:" request_data)
         ; Construct environment dictionary using request data
         env := this.RH.ParseRequest(request_data)
 		env.server := this
 		if env.command != "waitConfiguration"
-			logger("VSC -> DA Request: " request_data)
+			Logger("VSC -> DA Request: " request_data)
 		Logger("send to reponser: " env.command)
         result := this.application(env)
 
@@ -181,9 +181,9 @@ class RequestHandler
 		responseStr := JSON.Dump(response)
 		responseStr := this.ReplaceControlChr(responseStr, (response["type"] != "event"))
 		if response.type == "event"
-			logger("DA -> VSC event: " responseStr)
+			Logger("DA -> VSC event: " responseStr)
 		else
-			logger("DA -> VSC Response: " responseStr)
+			Logger("DA -> VSC Response: " responseStr)
 		responseStr := "Content-Length: " . (StrPut(responseStr, "utf-8")-1) . "`r`n`r`n" . responseStr
 
 		this.outStream.Write(responseStr)
@@ -209,7 +209,7 @@ class RequestHandler
 MakeServer(server_address, application)
 {
 	server := new ProtocolServer(server_address*)
-	server_address[1].SetProcesser(ObjBindMethod(server, "STDCallBack"))
+	server_address[1].SetProcessor(ObjBindMethod(server, "STDCallBack"))
 	EventDispatcher.On("recv", ObjBindMethod(server, "OnRecv"))
     server.SetApp(application)
     return server


### PR DESCRIPTION
When using [vscode-autohotkey2-lsp](https://github.com/thqby/vscode-autohotkey2-lsp) with `autohotkey-debug-adapter`, there were a few issues that came up while trying it out. 

I couldn't get the debug adapter to start, so I am contributing back some changes that might be helpful for others.

1. I fixed a few spelling mistakes (Invaild => Invalid) 
2. I have added support for ports to come as a port range (9100-9200) and randomly pick one from that range.

I think this fixes the issues with the [vscode-autohotkey2-lsp](https://github.com/thqby/vscode-autohotkey2-lsp).